### PR TITLE
Update toast durations and add success messages

### DIFF
--- a/src/views/CompanyDetailView.vue
+++ b/src/views/CompanyDetailView.vue
@@ -18,7 +18,7 @@ const fetchCompany = async () => {
     console.error('Error fetching company details:', error);
     toast.error(error.message || 'Failed to fetch company details', {
       position: 'top',
-      duration: 5000
+      duration: 6000
     });
   }
 };
@@ -30,7 +30,7 @@ const fetchPaymentMethods = async () => {
     console.error('Error fetching payment methods:', error);
     toast.error(error.message || 'Failed to fetch payment methods', {
       position: 'top',
-      duration: 5000
+      duration: 6000
     });
   }
 };
@@ -38,7 +38,10 @@ const fetchPaymentMethods = async () => {
 const updateCompanyDetails = async () => {
   try {
     await updateCompany(company.value.participantId, company.value);
-    toast.success('Company details updated successfully');
+    toast.success('Company details updated successfully', {
+      position: 'top',
+      duration: 5000
+    });
     await router.push(`/events/${route.params.eventId}/participants`);
   } catch (error) {
     console.error('Error updating company details:', error);

--- a/src/views/ParticipantsOfEventView.vue
+++ b/src/views/ParticipantsOfEventView.vue
@@ -78,8 +78,16 @@ const deleteParticipant = async (participant) => {
   try {
     if (participant.participantType === 'individual') {
       await deleteIndividual(participant.participantId)
+      toast.success('Individual deleted from event participants list', {
+        position: 'top',
+        duration: 5000
+      })
     } else {
       await deleteCompany(participant.participantId)
+      toast.success('Company removed from event participants list', {
+        position: 'top',
+        duration: 5000
+      })
     }
     await getParticipants() // Refresh the list after deletion
   } catch (error) {
@@ -95,8 +103,16 @@ const addParticipant = async () => {
   try {
     if (selectedParticipantType.value === 'individual') {
       await createIndividual(individualForm.value)
+      toast.success('Individual added to participants list', {
+        position: 'top',
+        duration: 5000
+      })
     } else {
       await createCompany(companyForm.value)
+      toast.success('Company added to participants list', {
+        position: 'top',
+        duration: 5000
+      })
     }
     await getParticipants() // Refresh participants list
     clearForm()


### PR DESCRIPTION
The commit increases the duration of error toasts from 5000ms to 6000ms in the CompanyDetailView.vue file. Also, it adds success toasts with a duration of 5000ms after successful operations such as update, delete and create individual/company in both files CompanyDetailView.vue and ParticipantsOfEventView.vue.